### PR TITLE
Make dismounting Quetzalcoatlus more foolproof

### DIFF
--- a/api/hq_lq.lua
+++ b/api/hq_lq.lua
@@ -686,7 +686,7 @@ function paleotest.hq_aerial_mount_logic(self, prty)
             end
         end
 
-        if ctrl.sneak then
+        if ctrl.sneak and ctrl.place then
             mobkit.clear_queue_low(self)
             mobkit.clear_queue_high(self)
             mob_core.detach(self.driver, {x = -1, y = 0, z = 0})


### PR DESCRIPTION
Currently, dismounting is performed by pressing "Shift" which is used for descending in fly mode or in some other flying-related mods. This causes confusion for players who might press it to descent but instead fall to the ground, die, and after that try to catch the Quetzalcoatlus back which might remain at the height, and catching it back might then be a quite difficult task.
This patch makes dismounting with Shift + Rightclick instead of just Shift.